### PR TITLE
Improve accuracy of full commit period

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Helpers to get pool state.
 ### Assumptions & Constraints:
 
 - An upkeep **will** happen every `UpdateInterval`
-- May not work if `FrontRunningInterval` is not completely divisible by `UpdateInterval`
 - Does not simulate keeper fees that get paid out of the pool
 - Does not simulate dynamic minting fees
 

--- a/contracts/PoolStateHelper.sol
+++ b/contracts/PoolStateHelper.sol
@@ -222,7 +222,6 @@ contract PoolStateHelper is
 
     /**
      * @notice The number of TotalCommitments that will be executed at the end of the frontrunning interval.
-     * Rounded up if not fully divisible.
      * @return fullCommitPeriod
      * @param pool The LeveragedPool contract.
      */
@@ -232,7 +231,19 @@ contract PoolStateHelper is
         override
         returns (uint256)
     {
-        return (pool.frontRunningInterval() / pool.updateInterval()) + 1;
+        uint256 currentUpdateIntervalId = IPoolCommitter2(pool.poolCommitter())
+            .updateIntervalId();
+
+        uint256 newUpdateIntervalId = PoolSwapLibrary
+            .appropriateUpdateIntervalId(
+                block.timestamp,
+                pool.lastPriceTimestamp(),
+                pool.frontRunningInterval(),
+                pool.updateInterval(),
+                currentUpdateIntervalId
+            );
+
+        return newUpdateIntervalId - currentUpdateIntervalId + 1;
     }
 
     function currentPoolState(ILeveragedPool2 pool)


### PR DESCRIPTION
Uses the logic in `PoolSwapLibrary.appropriateUpdateIntervalId` to determine the full commit period.

This change should allow for scenarios where the `FrontRunningInterval < UpdateInterval`, and if the `FrontRunningInterval` is not completely divisible by `UpdateInterval`.